### PR TITLE
added missing import traceback

### DIFF
--- a/bin/fby_client
+++ b/bin/fby_client
@@ -6,6 +6,7 @@ from serial import SerialException
 import datetime
 import time
 import requests
+from traceback import format_exception
 
 SAMPLE_TIME = 10 * 60
 SLEEP_TIME  = 0.50
@@ -100,7 +101,7 @@ def main( argv ):
             raise
         except Exception as a:
             exc_type, exc_value, exc_tb = sys.exc_info()
-            tb_list = traceback.format_exception( exc_type , exc_value , exc_tb)
+            tb_list = format_exception( exc_type , exc_value , exc_tb)
             config.logMessage("Exception caught" , long_msg = "".join( tb_list ))
             
 


### PR DESCRIPTION
fby_client uses module traceback which is not imported.

```
pi@raspberrypi:~ $ sudo systemctl status friskby
● friskby.service - Friskby logger
   Loaded: loaded (/etc/systemd/system/friskby.service; enabled)
   Active: failed (Result: exit-code) since Thu 2016-10-06 23:26:38 CEST; 3 days ago
  Process: 3728 ExecStart=/usr/local/friskby/bin/fby_client (code=exited, status=1/FAILURE)
 Main PID: 3728 (code=exited, status=1/FAILURE)

Oct 06 23:06:50 raspberrypi fby_client[3728]: Ran 22 tests in 10.485s
Oct 06 23:06:50 raspberrypi fby_client[3728]: OK (skipped=6)
Oct 06 23:26:38 raspberrypi fby_client[3728]: Traceback (most recent call last):
Oct 06 23:26:38 raspberrypi fby_client[3728]: File "/usr/local/friskby/bin/fby_client", line 108, in <module>
Oct 06 23:26:38 raspberrypi fby_client[3728]: main( sys.argv )
Oct 06 23:26:38 raspberrypi fby_client[3728]: File "/usr/local/friskby/bin/fby_client", line 103, in main
Oct 06 23:26:38 raspberrypi fby_client[3728]: tb_list = traceback.format_exception( exc_type , exc_value , exc_tb)
Oct 06 23:26:38 raspberrypi fby_client[3728]: NameError: global name 'traceback' is not defined
Oct 06 23:26:38 raspberrypi systemd[1]: friskby.service: main process exited, code=exited, status=1/FAILURE
Oct 06 23:26:38 raspberrypi systemd[1]: Unit friskby.service entered failed state.
```
