### PR TITLE
Median submission

### DIFF
--- a/bin/fby_client
+++ b/bin/fby_client
@@ -33,7 +33,7 @@ class FbyRunner(object):
         self._sample_time = 10 * 60
         self._sleep_time  = 0.50
         self._exception_count = 0 #  #exceptions since last success
-
+        self._accuracy = 4 # round observation to fourth digit
 
     @staticmethod
     def install(config):
@@ -95,7 +95,7 @@ class FbyRunner(object):
         device_id = config.getDeviceID( )
         client_pm10 = FriskbyClient(config , "%s_PM10" % device_id, VAR_PATH)
         client_pm25 = FriskbyClient(config , "%s_PM25" % device_id, VAR_PATH)
-        sampler = Sampler( SDS011(True) , self._sample_time , sleep_time = self._sleep_time )
+        sampler = Sampler( SDS011(True) , self._sample_time , sleep_time = self._sleep_time, accuracy = self._accuracy )
 
         while True:
             if self._exception_count >= 5:

--- a/bin/fby_client
+++ b/bin/fby_client
@@ -83,9 +83,8 @@ class FbyRunner(object):
 
 
     def post(self, client_pm10, client_pm25, data):
-        client_pm10.post( data[0].mean() )
-        client_pm25.post( data[1].mean() )
-
+        client_pm10.post( data[0].median() )
+        client_pm25.post( data[1].median() )
 
     def run(self):
         network_block( )

--- a/lib/sampler.py
+++ b/lib/sampler.py
@@ -4,10 +4,11 @@ from ts import TS
 
 class Sampler(object):
     
-    def __init__(self, reader, sample_time , sleep_time = 0.10):
+    def __init__(self, reader, sample_time , sleep_time = 0.10, accuracy = None):
         self.reader = reader
         self.sample_time = sample_time
         self.sleep_time = sleep_time
+        self.accuracy = accuracy
 
 
     def collect(self):
@@ -17,7 +18,7 @@ class Sampler(object):
             values = self.reader.read( )
             if len(data) == 0:
                 for x in range(len(values)):
-                    data.append( TS() )
+                    data.append( TS(accuracy=self.accuracy) )
                 
             for index,v in enumerate(values):
                 data[index].append( v )

--- a/lib/ts.py
+++ b/lib/ts.py
@@ -16,6 +16,10 @@ class TS(object):
     def __len__(self):
         return len(self.data)
 
+    def __getitem__(self, idx):
+        return self.data[idx]
+
+
     def append(self , d):
         if self.accuracy:
             d = round(d, self.accuracy)
@@ -35,7 +39,10 @@ class TS(object):
     def mean(self):
         if len(self) == 0:
             raise ValueError('Arithmetic mean of empty time series.')
-        return sum(self.data) / float(len(self))
+        m = sum(self.data) / float(len(self))
+        if self.accuracy:
+            return round(m, self.accuracy)
+        return m
 
     def median(self):
         if len(self) == 0:
@@ -49,4 +56,7 @@ class TS(object):
             raise ValueError('Standard deviation of too few values')
         m = self.mean()
         ss = sum((x-m)**2 for x in self.data)
-        return (ss/float(ld))**0.5
+        std = (ss/float(ld))**0.5
+        if self.accuracy:
+            return round(std, self.accuracy)
+        return std

--- a/lib/ts.py
+++ b/lib/ts.py
@@ -1,10 +1,14 @@
-
-
 class TS(object):
+    """A class for representing time series.
 
-    def __init__(self):
+    Remarkably close to just being a list.  But has mean() and median().
+
+    """
+
+    def __init__(self, data = None):
         self.data = []
-
+        if data:
+            self.data = [x for x in data]
 
     def __len__(self):
         return len(self.data)
@@ -12,6 +16,32 @@ class TS(object):
     def append(self , d):
         self.data.append( d )
 
+    def __repr__(self):
+        return str(self)
+
+    def __str__(self):
+        if len(self) < 10:
+            return str(self.data)
+        tmp1 = self.data[:4]
+        tmp2 = self.data[-4:]
+        return 'TS[%f %f %f %f ... %f %f %f %f]' % (tmp1[0], tmp1[1], tmp1[2], tmp1[3],
+                                                    tmp2[0], tmp2[1], tmp2[2], tmp2[3])
 
     def mean(self):
+        if len(self) == 0:
+            raise ValueError('Arithmetic mean of empty time series.')
         return sum(self.data) / len(self)
+
+    def median(self):
+        if len(self) == 0:
+            raise ValueError('Median of empty time series.')
+        tmp = sorted(self.data)
+        return tmp[len(self)//2]
+
+    def stddev(self):
+        ld = len(self.data)
+        if ld < 2:
+            raise ValueError('Standard deviation of too few values')
+        m = self.mean()
+        ss = sum((x-m)**2 for x in self.data)
+        return (ss/float(ld))**0.5

--- a/lib/ts.py
+++ b/lib/ts.py
@@ -3,17 +3,22 @@ class TS(object):
 
     Remarkably close to just being a list.  But has mean() and median().
 
+    Set accuracy = 3 to get rounding to third decimal.
     """
 
-    def __init__(self, data = None):
+    def __init__(self, data = None, accuracy=None):
         self.data = []
+        self.accuracy = accuracy
         if data:
-            self.data = [x for x in data]
+            for x in data:
+                self.append(x)
 
     def __len__(self):
         return len(self.data)
 
     def append(self , d):
+        if self.accuracy:
+            d = round(d, self.accuracy)
         self.data.append( d )
 
     def __repr__(self):
@@ -22,15 +27,15 @@ class TS(object):
     def __str__(self):
         if len(self) < 10:
             return str(self.data)
-        tmp1 = self.data[:4]
-        tmp2 = self.data[-4:]
-        return 'TS[%f %f %f %f ... %f %f %f %f]' % (tmp1[0], tmp1[1], tmp1[2], tmp1[3],
-                                                    tmp2[0], tmp2[1], tmp2[2], tmp2[3])
+        tmp = self.data[:4]
+        tmp += self.data[-4:]
+        fmt = 'TS[{}, {}, {}, {}, ..., {}, {}, {}, {}]'
+        return fmt.format(*tmp)
 
     def mean(self):
         if len(self) == 0:
             raise ValueError('Arithmetic mean of empty time series.')
-        return sum(self.data) / len(self)
+        return sum(self.data) / float(len(self))
 
     def median(self):
         if len(self) == 0:

--- a/tests/test_ts.py
+++ b/tests/test_ts.py
@@ -17,3 +17,31 @@ class TSTest(TestCase):
         ts.append( 5.0 )
         self.assertEqual( len(ts) , 3 )
         self.assertEqual( ts.mean() , 2.0 )
+
+    def setUp(self):
+        self._ts  = TS( [2.71828,3.141592,4.12310] )
+        self._tsa = TS( [2.71828,3.141592,4.12310], accuracy=2 )
+        self._tsb = TS( [6.1, 5.2, 4.3, 1.2, 2.3, 4.5, 5.6, 1000.123] )
+        self._tsc = TS( [6.1, 5.2, 4.3, 1.2, 2.3, 4.5, 5.6, 10.0,12.3] )
+
+    def test_ts_init(self):
+        self.assertEqual(3, len(self._ts))
+        self.assertEqual(3, len(self._tsa))
+        self.assertEqual(8, len(self._tsb))
+        self.assertEqual(9, len(self._tsc))
+        self.assertEqual(2.72, self._tsa[0])
+
+    def test_math_with_accuracy(self):
+        self.assertEqual(3.141592, self._ts.median())
+        self.assertEqual(3.14, self._tsa.median())
+
+        self.assertAlmostEqual(3.3276573, self._ts.mean())
+        self.assertEqual(3.33, self._tsa.mean())
+
+        self.assertAlmostEqual(0.5884131, self._ts.stddev())
+        self.assertEqual(0.59, self._tsa.stddev())
+
+    def test_median(self):
+        self.assertEqual(3.141592, self._ts.median())
+        self.assertEqual(5.2, self._tsb.median())
+        self.assertEqual(5.2, self._tsc.median())


### PR DESCRIPTION
With this PR we submit the median instead of the mean value.
It also adds a rounding scheme, where we round to 4 digits.

Added to TS:
- method `median` and `stddev`
- `str` and `repr` printing the underlying list
- added `accuracy`, if set, we round to `accuracy` many digits
- made `mean` more Python2 reliable (cast to float for division) 
