### PR TITLE
Added getMaxPostValue to DeviceConfig

### DIFF
--- a/lib/device_config.py
+++ b/lib/device_config.py
@@ -79,6 +79,11 @@ class DeviceConfig(object):
     def getGitFollow(self):
         return self.data["git_follow"]
 
+    def getMaxPostValue(self):
+        # This can in the future be changed to be a part of the config.
+        # It is the max value we want in the raw data field.
+        # The actual measurement should be sent as string value
+        return 100.0
 
     def updateRequired(self , new_config):
         if self.getGitFollow( ):

--- a/lib/friskby_client.py
+++ b/lib/friskby_client.py
@@ -24,9 +24,16 @@ class FriskbyClient(object):
 
     def post_value(self , timestamp , value):
         try:
+            string_val = ''
+            sensor_val = value
+            if value > self.device_config.getMaxPostValue():
+                string_val = str(value)
+                sensor_val = self.device_config.getMaxPostValue()
             data = {"timestamp" : timestamp,
                     "sensorid"  : self.sensor_id,
-                    "value"     : value,
+                    "string_value": string_val,
+                    "status"    : 0 if sensor_val == value else 3, # Value out of range
+                    "value"     : sensor_val,
                     "key"       : self.device_config.getPostKey( ) }
 
             respons = requests.post( self.device_config.getPostURL( ) , 


### PR DESCRIPTION
I added a max post value field in DeviceConfig

* If the sensor gives a value exceeding max post value
  * post max post value as true value
  * flag as value out of range
  * store the actual measured value as a string_val in the DB
* The max value is now 100, but should in the future be configurable in the config file

Ps., I don't know if `string_value: "1000.0"` and `status: 3` in the JSON is the correct way.  Want feedback.