### PR TITLE
IOError when serial.read times out

### DIFF
--- a/bin/fby_client
+++ b/bin/fby_client
@@ -75,12 +75,11 @@ class FbyRunner(object):
         data = None
         try:
             data = sampler.collect( )
-        except SerialException as se:
+        except (SerialException, IOError) as err:
             if self._exception_count < 5:
-                config.logMessage('Exception while collecting: %s' % str(se))
+                config.logMessage('Exception while collecting: %s' % str(err))
             self._exception_count += 1
-            sys.stderr.write('Exception in collect %d\n' % self._exception_count)
-            sys.stderr.write('Exception in collect %s\n' % str(se))
+            sys.stderr.write('Exception in collect %s\n' % str(err))
         return data
 
 

--- a/lib/sds011.py
+++ b/lib/sds011.py
@@ -22,6 +22,8 @@ class SDS011(object):
         # Read in loop until message start: AAC0
         while True:
             s = self.device.read(1)
+            if len(s) < 1:
+                raise IOError('Device timed out in attempt to read a byte')
             if ord(s) == SDS011.msg_start:
                 s = self.device.read(1)
                 if ord(s) == SDS011.msg_cmd:


### PR DESCRIPTION
No, we can get a non-sensical error message `ord(s) fails` when `serial.read()` times out.

This PR raises an IOError when `serial.read` times out.

We could potentially also increase the timeout (make it part of the config?), but I believe that this mostly happens when the device is actually disconnected, and hence timeout is fair enough.