### PR TITLE
Added try: str(a) for exception a

### DIFF
--- a/bin/fby_client
+++ b/bin/fby_client
@@ -112,10 +112,15 @@ class FbyRunner(object):
                 self.updateClient( self._config )
 
             except Exception as a:
+                err_msg = '(unknown error for %s)' % str(type(a))
+                try:
+                    err_msg = str(a)
+                except Exception:
+                    pass
                 exc_type, exc_value, exc_tb = sys.exc_info()
                 tb_list = format_exception( exc_type , exc_value , exc_tb)
                 if self._exception_count < 5:
-                    self._config.logMessage('Exception caught: "%s".' % str(a), long_msg = "".join( tb_list ))
+                    self._config.logMessage('Exception caught: "%s".' % err_msg, long_msg = "".join( tb_list ))
                 self._exception_count += 1
             else:
                 # try/except/else: if nothing has been raised we successfully posted


### PR DESCRIPTION
This is possibly a temporary check while we investigate how an exception can _not_ have a `__str__` function.

Attempt to fix #87 