### PR TITLE
WIP: The future is microservice architecture

### DIFF
--- a/bin/fby_client
+++ b/bin/fby_client
@@ -1,4 +1,15 @@
 #!/usr/bin/env python
+#
+# This is a script that should be invoked by systemd or cron once every 1 to 12
+# hours or so.  The update frequency is determined by fby_updater.service.  This
+# file is in term written by me, the update manager.
+#
+# The sole task of this is script is to read settings data from the cloud and
+# manage the sample and submit services.  I can also do database maintenance.
+
+from __future__ import print_function
+
+
 import sys
 import os
 from serial import SerialException
@@ -26,7 +37,15 @@ if os.getenv("FRISKBY_TEST"):
 else:
     from sds011 import SDS011
 
-
+#
+# This is just an update manager.  Its role is to:
+#
+# 1. download new configuration files and write etc/friskby.conf and .service
+#    files
+# 2. run the db.cleanup function
+#
+# it should be run ~once per hour, or around midnight or something
+#
 class FbyRunner(object):
 
     def __init__(self, argv):
@@ -83,6 +102,9 @@ class FbyRunner(object):
             sys.stderr.write('Exception in collect %s\n' % str(err))
         return data
 
+
+    def cleanup(self):
+        return self.db.drop_uploaded_rows()
 
     def post(self, client_pm10, client_pm25, data):
         client_pm10.post( data[0].median() )

--- a/bin/fby_sampler
+++ b/bin/fby_sampler
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+#
+# This is a simple script that should be invoked by systemd or cron once every
+# minute or so.  The sample frequency is determined by fby_sampler.service.
+# This file is in term written by the fby_client, the update manager.
+#
+# The sole task of this is script is to sample from SDS011 n times and send the
+# data to the friskby_dao object.
+
+
+from __future__ import print_function
+
+import sys
+import os
+
+if 'FRISKBY_TEST' in os.environ():
+    from mock_sds011 import SDS011
+else:
+    from sds011 import SDS011
+
+
+from sampler import Sampler
+
+ROOT = os.path.abspath( os.path.join( os.path.dirname( __file__ ) , "../" ))
+sys.path.insert(0 , os.path.join(ROOT , "lib"))
+CONFIG_FILE = os.path.join( ROOT , "etc/config.json")
+VAR_PATH = os.path.join(ROOT , "var")
+
+
+class FbySampler(object):
+
+    def __init__(self, argv):
+        self._sample_time = 10 * 60
+        self._sleep_time  = 0.50
+        self._accuracy = 4 # round observation to fourth digit
+        self._config = None
+        device_id = self._config.getDeviceID( )
+        client_pm10 = FriskbyClient(self._config , "%s_PM10" % device_id, VAR_PATH)
+        client_pm25 = FriskbyClient(self._config , "%s_PM25" % device_id, VAR_PATH)
+        sampler = Sampler(SDS011(True),
+                          self._sample_time,
+                          sleep_time = self._sleep_time,
+                          accuracy = self._accuracy)
+
+
+    def collect(self):
+        data = self.sampler.collect()
+        self.db.persist(data)
+
+def main():
+    s = FbySampler()
+    s.collect()
+
+if __name__ == '__main__':
+    main()

--- a/bin/fby_submitter
+++ b/bin/fby_submitter
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+#
+# This is a simple script that should be invoked by systemd or cron once every
+# 10 minutes or so.  The submit frequency is determined by
+# fby_submitter.service.  This file is in term written by the fby_client, the
+# update manager.
+#
+# The sole task of this is script is to read data from the friskby_dao object
+# and submit it to the cloud.
+
+from __future__ import print_function
+import sys
+import os
+
+ROOT = os.path.abspath( os.path.join( os.path.dirname( __file__ ) , "../" ))
+sys.path.insert(0 , os.path.join(ROOT , "lib"))
+CONFIG_FILE = os.path.join( ROOT , "etc/config.json")
+VAR_PATH = os.path.join(ROOT , "var")
+
+class FbySubmitter(object):
+
+    def __init__(self, argv):
+        self._config = None
+        self._limit = 100
+
+    def submit(self):
+        rows = self.db.rows(limit=self.limit)
+        client_pm10.post( data[0].median() )
+        client_pm25.post( data[1].median() )
+        self.db.update(rows, uploaded=True)
+
+
+def main():
+    s = FbySubmitter()
+    s.submit()
+
+if __name__ == '__main__':
+    main()

--- a/lib/friskby_dao.py
+++ b/lib/friskby_dao.py
@@ -1,0 +1,36 @@
+import json
+import sqlite3
+from os.path import isfile, abspath
+
+class FriskbyDao(object):
+    """A very simple access object to the samples.
+    Uses sqlite3 to persist sample data.  Available functions:
+    
+    1. persist(data)    --- store sampled values
+    2. rows(limit=100)  --- get limit number of non-uploaded rows
+    3. cleanup()        --- drop uploaded 
+    4. update(data,upl) --- set corresponding rows as uploaded
+
+    Needs a configuration object to get db_path and db_name.
+    """
+
+    def __init__(self, conf):
+        path = conf['db_path']
+        path = abspath(path)
+        if not isfile(path):
+            raise IOError('Provided DB "%s" is not a file.' % path)
+        self.__conn = sqlite3.connect(path)
+        self._db_name = conf['db_name']
+
+    def cleanup(self):
+        self.__conn.execute('DROP * FROM %s WHERE UPLOADED' % self._db_name)
+
+    def persist(self, data):
+        pass
+
+    def rows(self, limit = 100, uploaded = False):
+        pass
+
+    def update(self, data, uploaded = True):
+        pass
+


### PR DESCRIPTION
Get some fresh air before continuing.

This PR is a WIP-POC2B (that is _work in progress&proof of concept-to-be_).

# Microservice architecture
I believe that the friskby client would benefit from having small individual jobs for each individual task and let `systemd` or `cron` — tools proven to work over years — do the job they do best.

# Separation of power
I have tried to come up with the following separation of power:

0. The `friskby_dao` is a database (sqlite) interface.  It can
 ** store values (`id, sensor_id, value, timestamp, uploaded`)
 ** read and return values
 ** update rows in the database and mark them `uploaded`
 ** drop rows that are marked `uploaded`
1. The `fby_sampler` is now a very simple script that gets/reads
`etc/friskby.conf` and samples _n_ values from each of the sensors (specified in
`etc/friskby.conf`), and sends the data to the `friskby_dao`.  This script can
be run every 1 minute.
2. The `fby_submitter` is invoked every 10 minutes or 1 hour or so, and reads a
specified number of rows from  `friskby_dao`, uploads them to the cloud and if
successful, asks the `friskby_dao` to mark the rows as uploaded.
3. The `fby_client` or _update manager_ calls home every so often (2 -- 24
hours) and asks for a new configuration file.  If it exists, it updates the
`fby_sampler.service`, `fby_submitter.service`, its own `fby_client.service` as
well as `etc/friskby.conf` common configuration file.  This script will also ask
the `friskby_dao` to drop uploaded rows every now and then.

# Benefits
The benefits are several-fold.  But the most pressing is that the separation of
power leads to no interference: if the sampler breaks down, the update manager
will still work.  If the submitter goes into an infinite loop, the update
manager can kill it.

There is no state!  The only state is in the configuration file, service files
and in the database.  All of these are designed to handle state.  The database
is design to read and write efficiently and safely (not losing any data).

It becomes simpler to test.  Although there is a great framework for testing now
(and all tests will be retained throughout this refactoring), there is a lot to
benefit from the separation of these tasks.  We can stop testing data
persistence, since sqlite is thoroughly tested over years.

# Complexity of implementation
## New stuff
The database implementation is essentially the only new part, and the `sqlite3`
module is all we need; The implementation of `friskby_dao` will be trivial once
the scheme and config file is defined.

## Shuffling
The main complexity of implementation will be in reorganizing the codebase to
allow for the microservice architecture.  I am hopeful that this will also lead
to a simpler and cleaner codebase.
