### PR TITLE
added /etc/os-release to sysinfo

### DIFF
--- a/bin/fby_client
+++ b/bin/fby_client
@@ -6,7 +6,7 @@ from datetime import datetime as dt
 import time
 import requests
 from traceback import format_exception
-
+import json
 
 ROOT = os.path.abspath( os.path.join( os.path.dirname( __file__ ) , "../" ))
 sys.path.insert(0 , os.path.join(ROOT , "lib"))
@@ -18,6 +18,7 @@ from friskby_client import FriskbyClient
 from sampler import Sampler
 from device_config import DeviceConfig
 from git_module import GitModule
+from os_release import sys_info
 if os.getenv("FRISKBY_TEST"):
     try:
         from sds011 import SDS011
@@ -26,25 +27,15 @@ if os.getenv("FRISKBY_TEST"):
 else:
     from sds011 import SDS011
 
-
 def get_sys_info():
-    """This gets basic system information to log on startup"""
-    sysname, nodename, release, version, machine = os.uname()
-    python_vs, python_cc = sys.version.split('\n')
-    req_vs = '0.0.0'
-    local_time = dt.now().isoformat()
+    info = ''
     try:
-        req_vs = requests.__version__
-    except:
-        pass
-    return {'sysname': sysname,
-            'nodename': nodename,
-            'release':  release,
-            'version': version,
-            'python': python_vs,
-            'pythoncc': python_cc,
-            'requests': req_vs,
-            'localtime': local_time}
+        info = sys_info()
+        if info:
+            info = json.dumps(info, indent=4, sort_keys=True)
+    except Exception as e:
+        info = 'Error getting sys_info: "%s".' % e
+    return info
 
 class FbyRunner(object):
 
@@ -128,12 +119,8 @@ class FbyRunner(object):
     def run(self):
         network_block( )
         self._config = DeviceConfig( CONFIG_FILE )
-        sys_info = 'missing sys_info'
-        try:
-            sys_info = str(get_sys_info())
-        except:
-            pass
-        self._config.logMessage("Starting up", long_msg = sys_info)
+        long_msg = get_sys_info()
+        self._config.logMessage("Starting up", long_msg = long_msg)
         self._config.postGitVersion( )
 
         device_id = self._config.getDeviceID( )

--- a/lib/dist.py
+++ b/lib/dist.py
@@ -5,7 +5,8 @@ files = ["bin/fby_client",
          "lib/dist.py",
          "lib/sampler.py",
          "lib/sds011.py",
-         "lib/friskby_client.py"]
+         "lib/friskby_client.py",
+         "lib/os_release.py"]
 
 directories = ["var",
                "etc"]

--- a/lib/os_release.py
+++ b/lib/os_release.py
@@ -1,0 +1,56 @@
+from sys import version as sys_version
+from os import uname
+from os.path import isfile
+from datetime import datetime as dt
+
+def _read_os_release(pfx='LSB_'):
+    fname = '/etc/os-release'
+    if not isfile(fname):
+        return {}
+    def processline(ln):
+        return ln.strip().replace('"', '')
+    def splitline(ln, pfx=''):
+        if ln.count('=') == 1:
+            k,v = ln.split('=')
+            return pfx+k,v
+        return None
+    props = {}
+    with open(fname, 'r') as f:
+        for line in f:
+            kv = splitline(processline(line), pfx=pfx)
+            if kv:
+                props[kv[0]] = kv[1]
+    return props
+
+def sys_info():
+    """This gets basic system information to log on startup"""
+    sysname, nodename, release, version, machine = uname()
+    python_vs, python_cc = sys_version.split('\n')
+    req_vs = '0.0.0'
+    local_time = dt.now().isoformat()
+    lsb = None
+    try:
+        lsb = _read_os_release()
+    except:
+        pass
+    try:
+        import requests
+        req_vs = requests.__version__
+    except:
+        pass
+    if not lsb:
+        lsb = {}
+    sysinf =  {'sysname'  : sysname,
+               'nodename' : nodename,
+               'release'  :  release,
+               'version'  : version,
+               'python'   : python_vs,
+               'pythoncc' : python_cc,
+               'requests' : req_vs,
+               'localtime': local_time}
+    sysinf.update(lsb)
+    return sysinf
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(sys_info(), indent=4, sort_keys=True))

--- a/tests/test_fby_runner.py
+++ b/tests/test_fby_runner.py
@@ -10,4 +10,14 @@ class FbyRunnerTest(TestCase):
 
     def test_load(self):
         fby_client = main_module.FbyRunner( ["arg1","arg2"] )
-        
+
+    def test_sysinfo(self):
+        sys_info = main_module.get_sys_info()
+        self.assertTrue('sysname'  in sys_info)
+        self.assertTrue('requests' in sys_info)
+        self.assertTrue('python'   in sys_info)
+
+        import json
+        sys_info = main_module.get_sys_info()
+        sys_info = json.dumps(sys_info, indent=4, sort_keys=True)
+        print(sys_info)

--- a/tests/test_pylint.py
+++ b/tests/test_pylint.py
@@ -42,7 +42,8 @@ class PylintTest(TestCase):
                     "lib/git_module.py",
                     "lib/sds011.py",
                     "lib/wifi_config.py",
-                    "lib/service.py"]:
+                    "lib/service.py",
+                    "lib/os_release.py"]:
                      
             exit_code = subprocess.check_call(["pylint" , "-E", lib])
             self.assertEqual( exit_code , 0 )


### PR DESCRIPTION
The file `/etc/os-release` is a file many OS's support, especially debian/ubuntu/raspbian, and its content may be something like
```
PRETTY_NAME="Raspbian GNU/Linux 8 (jessie)"
NAME="Raspbian GNU/Linux"
VERSION_ID="8"
VERSION="8 (jessie)"
ID=raspbian
ID_LIKE=debian
HOME_URL="http://www.raspbian.org/"
SUPPORT_URL="http://www.raspbian.org/RaspbianForums"
BUG_REPORT_URL="http://www.raspbian.org/RaspbianBugs"
```
We internalize this file and add it to `sysinfo` in the `Long msg` of the startup log.

look, @joakim-hove ... tests! :)

