### PR TITLE
Use SQLITE as storage backend

### DIFF
--- a/bin/fby_client
+++ b/bin/fby_client
@@ -14,7 +14,8 @@ CONFIG_FILE = os.path.join(ROOT, "etc/config.json")
 VAR_PATH = os.path.join(ROOT, "var")
 
 import dist
-from friskby_client import FriskbyClient
+from fby_submitter import FriskbySubmitter
+from friskby_dao import FriskbyDao
 from sampler import Sampler
 from device_config import DeviceConfig
 from git_module import GitModule
@@ -45,6 +46,17 @@ class FbyRunner(object):
         self._exception_count = 0 #  #exceptions since last success
         self._accuracy = 4 # round observation to fourth digit
         self._config = None
+        if not var_path:
+            var_path = '/usr/local/friskby/var'
+        self._sql_path = os.path.join(var_path, 'friskby.sql')
+        self._dao = FriskbyDao(self._sql_path)
+        self._submitter = FriskbySubmitter(self._dao)
+
+    def get_dao(self):
+        return self._dao
+
+    def get_submitter(self):
+        return self._submitter
 
     @staticmethod
     def install(config):
@@ -82,22 +94,6 @@ class FbyRunner(object):
                 config.logMessage("Rollback complete")
 
 
-    def collect(self, sampler, config):
-        data = None
-        try:
-            data = sampler.collect( )
-        except (SerialException, IOError) as err:
-            if self._exception_count < 5:
-                self._config.logMessage('Exception while collecting: %s' % str(err))
-            self._exception_count += 1
-            sys.stderr.write('Exception in collect %s\n' % str(err))
-        return data
-
-
-    def post(self, client_pm10, client_pm25, data):
-        client_pm10.post( data[0].median() )
-        client_pm25.post( data[1].median() )
-
     def _handle_post_exception(self, err, exc_info):
         self._exception_count += 1
         if self._exception_count > 5:
@@ -123,22 +119,25 @@ class FbyRunner(object):
         self._config.logMessage("Starting up", long_msg=long_msg)
         self._config.postGitVersion()
 
-        device_id = self._config.getDeviceID( )
-        client_pm10 = FriskbyClient(self._config , "%s_PM10" % device_id, VAR_PATH)
-        client_pm25 = FriskbyClient(self._config , "%s_PM25" % device_id, VAR_PATH)
-        sampler = Sampler( SDS011(True) , self._sample_time , sleep_time = self._sleep_time, accuracy = self._accuracy )
+        self._submitter.set_config(self._config)
+        sampler = Sampler(SDS011(True), self._dao,
+                          self._sample_time, sleep_time=self._sleep_time,
+                          accuracy=self._accuracy)
 
         while True:
             if self._exception_count >= 5:
                 time.sleep(30)
             try:
-                data = self.collect(sampler , self._config)
-                if not data:
-                    continue
-                self.post(client_pm10, client_pm25, data)
-                self.updateClient( self._config )
-            except Exception as a:
-                self._handle_post_exception(a, sys.exc_info())
+                print('Collecting ...')
+                sys.stdout.flush()
+                sampler.collect()
+
+                self._submitter.post()
+                print('Updating ...')
+                sys.stdout.flush()
+                self.updateClient(self._config)
+            except Exception as err:
+                self._handle_post_exception(err, sys.exc_info())
             else:
                 # try/except/else: if nothing has been raised we successfully posted
                 self._exception_count = 0

--- a/bin/fby_client
+++ b/bin/fby_client
@@ -8,10 +8,10 @@ import requests
 from traceback import format_exception
 import json
 
-ROOT = os.path.abspath( os.path.join( os.path.dirname( __file__ ) , "../" ))
-sys.path.insert(0 , os.path.join(ROOT , "lib"))
-CONFIG_FILE = os.path.join( ROOT , "etc/config.json")
-VAR_PATH = os.path.join(ROOT , "var")
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))
+sys.path.insert(0, os.path.join(ROOT, "lib"))
+CONFIG_FILE = os.path.join(ROOT, "etc/config.json")
+VAR_PATH = os.path.join(ROOT, "var")
 
 import dist
 from friskby_client import FriskbyClient
@@ -39,20 +39,20 @@ def get_sys_info():
 
 class FbyRunner(object):
 
-    def __init__(self, argv):
+    def __init__(self, var_path=None):
         self._sample_time = 10 * 60
-        self._sleep_time  = 0.50
+        self._sleep_time = 0.5
         self._exception_count = 0 #  #exceptions since last success
         self._accuracy = 4 # round observation to fourth digit
         self._config = None
 
     @staticmethod
     def install(config):
-        git_module = GitModule( url = config.getRepoURL() )
-        git_module.checkout( config.getGitRef( ) )
-        git_module.runTests( "tests/run_tests" )
-        git_module.install( ROOT , files = dist.files , directories = dist.directories )
-        config.save( filename = CONFIG_FILE )
+        git_module = GitModule(url=config.getRepoURL())
+        git_module.checkout(config.getGitRef())
+        git_module.runTests("tests/run_tests")
+        git_module.install(ROOT, files=dist.files, directories=dist.directories)
+        config.save(filename=CONFIG_FILE)
 
 
     @classmethod
@@ -63,22 +63,22 @@ class FbyRunner(object):
     @classmethod
     def restart(cls, config):
         cls.install(config)
-        os.execl( __file__ , __file__)
+        os.execl(__file__, __file__)
 
         raise Exception("Fatal error: os.execl() returned - trying to rollback")
 
     @classmethod
     def updateClient(cls, config):
-        new_config = config.downloadNew( )
-        if config.updateRequired( new_config ):
+        new_config = config.downloadNew()
+        if config.updateRequired(new_config):
             try:
                 config.logMessage("Restarting client - new version:%s" % new_config.getGitRef())
-                cls.restart( new_config )
-            except Exception as exc:
+                cls.restart(new_config)
+            except:
                 exc_type, exc_value, exc_tb = sys.exc_info()
-                tb_list = format_exception( exc_type , exc_value , exc_tb)
-                config.logMessage("Restart failed - trying rollback" , long_msg = "".join( tb_list ))
-                cls.rollback( config )
+                tb_list = format_exception(exc_type, exc_value, exc_tb)
+                config.logMessage("Restart failed - trying rollback", long_msg="".join(tb_list))
+                cls.rollback(config)
                 config.logMessage("Rollback complete")
 
 
@@ -108,20 +108,20 @@ class FbyRunner(object):
         except Exception:
             pass
         exc_type, exc_value, exc_tb = exc_info
-        tb_list = format_exception( exc_type , exc_value , exc_tb)
+        tb_list = format_exception(exc_type, exc_value, exc_tb)
         log_payload = 'Exception caught: "%s".' % (err_msg)
-        traceback = "".join( tb_list )
+        traceback = "".join(tb_list)
         try:
-            self._config.logMessage(log_payload, long_msg = traceback)
-        except Exception as err:
+            self._config.logMessage(log_payload, long_msg=traceback)
+        except:
             sys.stderr.write('Error submitting log message!')
 
     def run(self):
-        network_block( )
-        self._config = DeviceConfig( CONFIG_FILE )
+        network_block()
+        self._config = DeviceConfig(CONFIG_FILE)
         long_msg = get_sys_info()
-        self._config.logMessage("Starting up", long_msg = long_msg)
-        self._config.postGitVersion( )
+        self._config.logMessage("Starting up", long_msg=long_msg)
+        self._config.postGitVersion()
 
         device_id = self._config.getDeviceID( )
         client_pm10 = FriskbyClient(self._config , "%s_PM10" % device_id, VAR_PATH)
@@ -157,9 +157,9 @@ def network_block():
             if response.status_code == 200:
                 break
         except Exception:
-            time.sleep( 2 )
+            time.sleep(2)
 
 
 if __name__ == "__main__":
-    fby = FbyRunner( sys.argv )
+    fby = FbyRunner()
     fby.run()

--- a/bin/fby_client
+++ b/bin/fby_client
@@ -113,7 +113,7 @@ class FbyRunner(object):
             sys.stderr.write('Error submitting log message!')
 
     def run(self):
-        network_block()
+
         self._config = DeviceConfig(CONFIG_FILE)
         long_msg = get_sys_info()
         self._config.logMessage("Starting up", long_msg=long_msg)
@@ -126,7 +126,9 @@ class FbyRunner(object):
 
         while True:
             if self._exception_count >= 5:
-                time.sleep(30)
+                print('Warning: exception count exceeded')
+                sys.stdout.flush()
+                sys.exit('Exception count exceeded.  Giving up.')
             try:
                 print('Collecting ...')
                 sys.stdout.flush()
@@ -141,22 +143,6 @@ class FbyRunner(object):
             else:
                 # try/except/else: if nothing has been raised we successfully posted
                 self._exception_count = 0
-
-def network_block():
-    url = "http://www.google.com"
-    timeout = 120
-    start = dt.now()
-    while True:
-        dt_now = dt.now() - start
-        if dt_now.total_seconds() > timeout:
-            sys.exit("No network contact established - giving up")
-
-        try:
-            response = requests.get(url, timeout=10)
-            if response.status_code == 200:
-                break
-        except Exception:
-            time.sleep(2)
 
 
 if __name__ == "__main__":

--- a/lib/device_config.py
+++ b/lib/device_config.py
@@ -16,7 +16,7 @@ class DeviceConfig(object):
     def __init__(self , filename , post_key = None):
         if not os.path.isfile( filename ):
             raise IOError("No such file: %s" % filename)
-        
+
         config = json.load( open(filename) )
         if not "post_key" in config:
             if not post_key is None:
@@ -48,7 +48,7 @@ class DeviceConfig(object):
     def save(self , filename = None):
         if filename is None:
             filename  = self.filename
-        
+
         path = os.path.dirname( filename )
         if not os.path.isdir( path ):
             os.makedirs( path )
@@ -62,7 +62,7 @@ class DeviceConfig(object):
 
     def getConfigPath(self):
         return self.data["config_path"]
-        
+
     def getPostURL(self):
         return "%s/%s" % (self.data["server_url"], self.data["post_path"])
 
@@ -115,7 +115,7 @@ class DeviceConfig(object):
             return self
 
 
-            
+
     @classmethod
     def download(cls , url , post_key = None):
         response = requests.get(url, timeout=10)
@@ -126,14 +126,14 @@ class DeviceConfig(object):
         data = json.loads(response.content)
         tmp = urlparse( url )
         config = data["client_config"]
-        config["server_url"] = "%s://%s" % (tmp.scheme , tmp.netloc) 
+        config["server_url"] = "%s://%s" % (tmp.scheme , tmp.netloc)
         with open(config_file,"w") as f:
             f.write( json.dumps(config) )
-            
+
         config = DeviceConfig( config_file , post_key = post_key)
-        os.unlink( config_file ) 
+        os.unlink( config_file )
         config.filename = None
-        
+
         return config
 
     def logMessage( self , msg , long_msg = None):
@@ -166,7 +166,7 @@ class DeviceConfig(object):
                 "git_ref" : "%s / %s" % (self.getGitRef() , self.sha)}
         headers = {"Content-Type": "application/json"}
 
-        response = requests.put("%s/sensor/api/device/%s/" % (self.getServerURL(), self.getDeviceID( )), 
+        response = requests.put("%s/sensor/api/device/%s/" % (self.getServerURL(), self.getDeviceID( )),
                                 data = json.dumps( data ) ,
                                 headers = headers,
                                 timeout=10)

--- a/lib/device_config.py
+++ b/lib/device_config.py
@@ -60,6 +60,13 @@ class DeviceConfig(object):
     def getServerURL(self):
         return self.data["server_url"]
 
+    def getSensorId(self, sensor_type):
+        vals = self.data['sensor_list']
+        for s_id in vals:
+            if sensor_type in s_id:
+                return s_id
+        return None
+
     def getConfigPath(self):
         return self.data["config_path"]
 

--- a/lib/dist.py
+++ b/lib/dist.py
@@ -6,6 +6,8 @@ files = ["bin/fby_client",
          "lib/sampler.py",
          "lib/sds011.py",
          "lib/friskby_client.py",
+         "lib/friskby_dao.py",
+         "lib/fby_submitter.py",
          "lib/os_release.py"]
 
 directories = ["var",

--- a/lib/dist.py
+++ b/lib/dist.py
@@ -10,5 +10,3 @@ files = ["bin/fby_client",
 
 directories = ["var",
                "etc"]
-
-

--- a/lib/fby_submitter.py
+++ b/lib/fby_submitter.py
@@ -1,0 +1,61 @@
+import sys
+import json
+import requests
+
+class FriskbySubmitter(object):
+    """This class submits data from a database to the friskby cloud, then proceeds
+    to mark the uploaded data as such.
+
+    """
+
+    def __init__(self, dao):
+        self.dao = dao
+
+    def set_config(self, device_config):
+        self.device_config = device_config
+
+    def get_dao(self):
+        return self.dao
+
+    def _upload(self, rows):
+        print('Attempting to upload.')
+        sys.stdout.flush()
+        # id, value, sensor, timestamp, uploaded
+        data = {}
+        for row in rows:
+            id_, value, sensor, timestamp, _ = row
+            if sensor not in data:
+                data[sensor] = []
+            data[sensor].append((id_, value, sensor, timestamp))
+
+        print('Connecting.')
+        sys.stdout.flush()
+        for sensor in data:
+            sensor_id = self.device_config.getSensorId(sensor)
+            push = {"sensorid"   : sensor_id,
+                    "value_list" : [(x[3].isoformat(), x[1]) for x in data[sensor]], # (time, val)
+                    "key"        : self.device_config.getPostKey()}
+            print('Posting to %s' % self.device_config.getPostURL())
+            print(push)
+            sys.stdout.flush()
+            respons = requests.post(self.device_config.getPostURL(),
+                                    headers={'Content-Type': 'application/json'},
+                                    data=json.dumps(push),
+                                    timeout=30)
+            print('posted %s' % sensor)
+            sys.stdout.flush()
+            if respons.status_code != 201:
+                respons.raise_for_status()
+                raise Exception('Server did not respond with 201 Created.  Response: %d %s'
+                                % (respons.status_code, respons.text))
+            respons.connection.close()
+        return True # no exception, everything written
+
+    def post(self):
+        if self.device_config is None:
+            raise ValueError('Device config not set!')
+        to_upload = self.dao.get_non_uploaded()
+        print('Submitting ...')
+        sys.stdout.flush()
+        if self._upload(to_upload):
+            self.dao.mark_uploaded(to_upload)

--- a/lib/friskby_dao.py
+++ b/lib/friskby_dao.py
@@ -1,0 +1,116 @@
+import sys
+from sys import stderr, argv
+from os.path import abspath, isfile
+import sqlite3
+from datetime import datetime as dt
+from dateutil import parser as dt_parser
+
+def _insert(val, sensor):
+    """Returns INSERT query"""
+    query = "INSERT INTO samples (id, value, sensor, timestamp) VALUES (NULL, %f, '%s', '%s');"
+    return query % (val, sensor, dt.utcnow())
+
+class FriskbyDao(object):
+
+    def __init__(self, sql_path):
+        """The sqlite db has a table called 'samples' with schema
+        id, value, sensor, timestamp, uploaded
+        """
+        self._sql_path = abspath(sql_path)
+        self.__init_sql()
+
+    def get_path(self):
+        return self._sql_path
+
+    def __init_sql(self):
+        if not isfile(self._sql_path):
+            _id = '`id` INTEGER PRIMARY KEY'
+            _val = '`value` FLOAT NOT NULL'
+            _sen = '`sensor` TEXT NOT NULL'
+            _date = '`timestamp` TEXT NOT NULL'
+            _upl = '`uploaded` BOOL DEFAULT 0'
+            _create = 'CREATE TABLE samples (%s, %s, %s, %s, %s);'
+            schema = _create % (_id, _val, _sen, _date, _upl)
+            conn = sqlite3.connect(self._sql_path)
+            conn.execute(schema)
+            conn.close()
+
+    def get_num_rows(self, uploaded_status=None):
+        """Gets num rows in sql storage.  If uploaded_status is set to True, we
+        fetch number of rows that are marked uploaded, if uploaded_status is set
+        to False, we fetch number of rows that are marked as not uploaded.
+        """
+        query = 'SELECT COUNT(uploaded) FROM samples'
+        if uploaded_status is not None:
+            if uploaded_status:
+                query += ' WHERE uploaded'
+            else:
+                query += ' WHERE NOT uploaded'
+        query += ';'
+        conn = sqlite3.connect(self._sql_path)
+        result = conn.execute(query)
+        num = result.fetchone()[0]
+        conn.close()
+        return num
+
+
+    def get_non_uploaded(self, limit=100):
+        sub_q = "id, value, sensor, datetime(timestamp, 'localtime'), uploaded"
+        query = 'SELECT %s FROM samples WHERE NOT `uploaded` LIMIT %d;'
+        try:
+            conn = sqlite3.connect(self._sql_path)
+            result = conn.execute(query % (sub_q, limit))
+            data = result.fetchall()
+            conn.close()
+            print('dao fetched %d rows of non-uploaded data' % len(data))
+            sys.stdout.flush()
+            for i in range(len(data)):
+                id_, val_, sens_, dt_, upl_ = data[i]
+                data[i] = id_, val_, sens_, dt_parser.parse(dt_), upl_
+            return data
+        except Exception as err:
+            stderr.write('Error on reading data: %s.\n' % err)
+
+    def persist_ts(self, data):
+        ts_pm10, ts_pm25 = data
+        q10 = _insert(ts_pm10.median(), 'PM10')
+        q25 = _insert(ts_pm25.median(), 'PM25')
+        try:
+            conn = sqlite3.connect(self._sql_path)
+            conn.execute(q10)
+            conn.execute(q25)
+            conn.commit()
+            conn.close()
+        except Exception as err:
+            stderr.write('Error on persisting data: %s.\n' % err)
+        print('Persisted data.')
+        sys.stdout.flush()
+
+    def mark_uploaded(self, data):
+        print('dao marking ...')
+        sys.stdout.flush()
+        query = 'UPDATE samples SET uploaded=1 WHERE id=%s'
+        try:
+            conn = sqlite3.connect(self._sql_path)
+            conn.execute('begin')
+            for row in data:
+                # id, value, sensor, timestamp, uploaded
+                id_ = row[0]
+                conn.execute(query % id_)
+            conn.commit()
+            conn.close()
+        except Exception as err:
+            stderr.write('Error on setting UPLOADED data! %s.\n' % err)
+
+
+    def __repr__(self):
+        try:
+            num, num_up = self.get_num_rows(), self.get_num_rows(uploaded_status=True)
+            fmt = 'FriskbyDao(num_rows = %s, non_uploaded = %s, path = %s)'
+            return fmt % (num, num_up, self._sql_path)
+        except:
+            return 'FriskbyDao(path = %s)' % (self._sql_path)
+
+if __name__ == '__main__':
+    if len(argv) > 1:
+        FriskbyDao(argv[1])

--- a/lib/sampler.py
+++ b/lib/sampler.py
@@ -1,33 +1,54 @@
+import sys
 import time
-import datetime
+from datetime import datetime as dt
+
 from ts import TS
+from friskby_dao import FriskbyDao
 
 class Sampler(object):
-    
-    def __init__(self, reader, sample_time , sleep_time = 0.10, accuracy = None):
+    """This class is initialized with a reader (a sensor of type SDS011), a dao and
+    sample time.  The collect method collects data for `sample_time` amount of
+    time, and then asks the FriskbyDao to persist this data.
+
+    """
+
+    def __init__(self, reader, dao, sample_time, sleep_time=0.10, accuracy=None):
+        """
+        Takes a reader (sensor) and a dao, and collects data and persists to dao.
+        """
         self.reader = reader
         self.sample_time = sample_time
         self.sleep_time = sleep_time
         self.accuracy = accuracy
-
+        self.dao = dao
 
     def collect(self):
-        data = []
-        start = datetime.datetime.now( )
+        """Reads values from the sensor and writes to dao.
+        """
+        # reader/sds011 returns (PM10, PM25)
+        data = (TS(accuracy=self.accuracy), TS(accuracy=self.accuracy))
+        print('\tShh, I am collecting.')
+        sys.stdout.flush()
+        start = dt.now()
         while True:
-            values = self.reader.read( )
-            if len(data) == 0:
-                for x in range(len(values)):
-                    data.append( TS(accuracy=self.accuracy) )
-                
-            for index,v in enumerate(values):
-                data[index].append( v )
-                
-            dt = datetime.datetime.now( ) - start
-            if dt.total_seconds() >= self.sample_time:
+            pm10, pm25 = self.reader.read()
+            data[0].append(pm10)
+            data[1].append(pm25)
+
+            dt_now = dt.now() - start
+            if dt_now.total_seconds() >= self.sample_time:
                 break
-            
-            time.sleep( self.sleep_time )
+            time.sleep(self.sleep_time)
+        print('\tDone collecting, storing and returning.')
+        sys.stdout.flush()
+        self.dao.persist_ts(data)
 
 
-        return data
+if __name__ == '__main__':
+    if len(sys.argv) > 1:
+        dao = FriskbyDao(sys.argv[1])
+        from sds011 import SDS011
+        sam = Sampler(SDS011(True), dao, 10) # 10 sec
+        sam.collect()
+    else:
+        sys.stderr.write('Please specify database file.\n')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 gitpython
 pyserial
 pylint
+python-dateutil

--- a/tests/test_dao.py
+++ b/tests/test_dao.py
@@ -1,0 +1,82 @@
+from tempfile import NamedTemporaryFile as temp
+from unittest import TestCase
+from random import random as rnd
+import sqlite3
+from datetime import datetime as dt
+from ts import TS
+from friskby_dao import FriskbyDao
+
+def rand():
+    return round(rnd()*100, 2)
+
+def gen_rand_ts():
+    t = TS()
+    for _ in range(3):
+        t.append(rand())
+    return t
+
+class DaoTest(TestCase):
+
+    def setUp(self):
+        tmpf = temp(delete=False)
+        self.fname = tmpf.name + '_db.sql'
+        tmpf.close()
+        self.dao = FriskbyDao(self.fname)
+
+    def test_created(self):
+        q = "SELECT name FROM sqlite_master WHERE type='table';"
+        conn = sqlite3.connect(self.fname)
+        c = conn.execute(q)
+        result = c.fetchall()
+        self.assertEqual(1, len(result))
+        self.assertEqual('samples', result[0][0])
+
+    def _do_test_num_upl(self, dao, exp_num_all, exp_num_upl, exp_num_nup):
+        num_all, num_upl, num_nup = (dao.get_num_rows(),
+                                     dao.get_num_rows(uploaded_status=True),
+                                     dao.get_num_rows(uploaded_status=False))
+        self.assertEqual(exp_num_all, num_all)
+        self.assertEqual(exp_num_upl, num_upl)
+        self.assertEqual(exp_num_nup, num_nup)
+
+    def test_persist(self):
+        num_data = 13
+        for _ in range(num_data):
+            t10 = gen_rand_ts()
+            t25 = gen_rand_ts()
+            self.dao.persist_ts((t10, t25))
+
+        self._do_test_num_upl(self.dao, 2*num_data, 0, 2*num_data)
+
+        data = self.dao.get_non_uploaded(limit=30)
+        self.assertEqual(2*num_data, len(data))
+
+    def test_mark_uploaded(self):
+        num_data = 17
+        for _ in range(num_data):
+            t10 = gen_rand_ts()
+            t25 = gen_rand_ts()
+            self.dao.persist_ts((t10, t25))
+        print(repr(self.dao))
+
+        self._do_test_num_upl(self.dao, 2*num_data, 0, 2*num_data)
+
+        data = self.dao.get_non_uploaded(limit=30)
+        self.assertEqual(30, len(data))
+        self.dao.mark_uploaded(data)
+        data = self.dao.get_non_uploaded(limit=30)
+        self.assertEqual(4, len(data)) # total 34, marked 30
+        print(repr(self.dao))
+
+        # test num / num upl / num non-upl
+        self._do_test_num_upl(self.dao, 2*num_data, 30, 2*num_data - 30)
+
+    def test_localtime(self):
+        t10 = gen_rand_ts()
+        t25 = gen_rand_ts()
+        now = dt.now()
+        self.dao.persist_ts((t10, t25))
+        out = self.dao.get_non_uploaded(limit=1)[0]
+        delta = now - out[3]
+        # checking that we're in the same timezone
+        self.assertTrue(abs(delta.total_seconds()) < 1000)

--- a/tests/test_fby_runner.py
+++ b/tests/test_fby_runner.py
@@ -8,8 +8,12 @@ main_module = imp.load_source("fby_client" , client_file)
 
 class FbyRunnerTest(TestCase):
 
+    def setUp(self):
+        self._tmp_f = '/tmp/%d' % randint(2**30, 2**32)
+        os.mkdir(self._tmp_f)
+
     def test_load(self):
-        fby_client = main_module.FbyRunner( ["arg1","arg2"] )
+        fby_client = main_module.FbyRunner(var_path=self._tmp_f)
 
     def test_sysinfo(self):
         sys_info = main_module.get_sys_info()

--- a/tests/test_fby_runner.py
+++ b/tests/test_fby_runner.py
@@ -1,6 +1,8 @@
-import os.path
+import os
 from unittest import TestCase
 import imp
+from random import randint
+import sys
 
 client_file = os.path.abspath( os.path.join( os.path.dirname(__file__) , "../bin/fby_client"))
 main_module = imp.load_source("fby_client" , client_file)
@@ -25,3 +27,10 @@ class FbyRunnerTest(TestCase):
         sys_info = main_module.get_sys_info()
         sys_info = json.dumps(sys_info, indent=4, sort_keys=True)
         print(sys_info)
+
+    def test_dao_and_submitter(self):
+        fby_client = main_module.FbyRunner(var_path=self._tmp_f)
+        dao = fby_client.get_dao()
+        self.assertEqual(self._tmp_f + '/friskby.sql', dao.get_path())
+        sub = fby_client.get_submitter()
+        self.assertEqual(self._tmp_f + '/friskby.sql', sub.get_dao().get_path())

--- a/tests/test_friskby_client.py
+++ b/tests/test_friskby_client.py
@@ -37,7 +37,6 @@ class FriskbyClientCTest(TestCase):
 
         os.environ["FRISKBY_TEST"] = "True"
         client = imp.load_source( "client" , client_path )
-        client.network_block( )
         del os.environ["FRISKBY_TEST"]
 
     @skipUnless(network, "Requires network access")

--- a/tests/test_pylint.py
+++ b/tests/test_pylint.py
@@ -43,7 +43,10 @@ class PylintTest(TestCase):
                     "lib/sds011.py",
                     "lib/wifi_config.py",
                     "lib/service.py",
-                    "lib/os_release.py"]:
-                     
+                    "lib/friskby_dao.py",
+                    "lib/fby_submitter",
+                    "lib/os_release.py",
+                    "bin/fby_client"]:
+
             exit_code = subprocess.check_call(["pylint" , "-E", lib])
             self.assertEqual( exit_code , 0 )

--- a/tests/test_pylint.py
+++ b/tests/test_pylint.py
@@ -3,7 +3,7 @@ import requests
 import shutil
 import sys
 import json
-import tempfile 
+import tempfile
 from unittest import TestCase, skipUnless
 import os.path
 import stat
@@ -35,8 +35,8 @@ class PylintTest(TestCase):
     @skipUnless(have_pylint,"Must have pylint executable installed")
     def test_library(self):
         sys.path.insert( 0, os.path.join( self.ROOT , "lib"))
-        for lib in ["lib/ts.py" , 
-                    "lib/device_config.py", 
+        for lib in ["lib/ts.py" ,
+                    "lib/device_config.py",
                     "lib/sampler.py",
                     "lib/dist.py",
                     "lib/git_module.py",

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -1,10 +1,9 @@
-import tempfile 
-import datetime
+from tempfile import NamedTemporaryFile as temp
+from datetime import datetime as dt
 from unittest import TestCase
-import os.path
-import stat
-from sampler import Sampler
 
+from sampler import Sampler
+from friskby_dao import FriskbyDao
 from serial import SerialException
 
 try:
@@ -15,15 +14,22 @@ except SerialException:
 
 class SamplerTest(TestCase):
 
+    def setUp(self):
+        tmpf = temp(delete=False)
+        self.fname = tmpf.name + '_db.sql'
+        tmpf.close()
+        self.dao = FriskbyDao(self.fname)
+
     def test_sampler(self):
         sample_time = 2
         sleep_time = 0.10
 
-        start = datetime.datetime.now()
-        sampler = Sampler( SDS011(True) , sample_time = sample_time , sleep_time = sleep_time )
-        data = sampler.collect( )
-        stop = datetime.datetime.now( )
-        
-        dt = stop - start
-        self.assertTrue( (dt.total_seconds() - sample_time) > 0)
-        
+        start = dt.now()
+        sampler = Sampler(SDS011(True), self.dao, sample_time=sample_time, sleep_time=sleep_time)
+        sampler.collect()
+        stop = dt.now()
+
+        delta = stop - start
+        self.assertTrue((delta.total_seconds() - sample_time) > 0)
+        data = self.dao.get_non_uploaded(limit=30)
+        self.assertTrue(len(data) > 0)


### PR DESCRIPTION
The sampler now persists data to sqlite3.  The sqlite file is in `/usr/local/friskby/var/friskby.db` and looks like this:
```
sqlite> .open friskby.sql 
sqlite> SELECT * FROM samples;
1|1.6|PM10|2017-02-21 22:44:18.488728|1
2|1.5|PM25|2017-02-21 22:44:18.489511|1
3|1.7|PM10|2017-02-21 22:56:55.095778|1
4|1.4|PM25|2017-02-21 22:56:55.095891|1
5|2.4|PM10|2017-02-21 22:57:56.096010|1
6|1.5|PM25|2017-02-21 22:57:56.096117|1
7|2.2|PM10|2017-02-21 22:58:57.115996|1
8|1.5|PM25|2017-02-21 22:58:57.116103|1
9|2.2|PM10|2017-02-21 22:59:58.144806|1
...
```

The columns are `id|value|sensor|timestamp|uploaded` where `uploaded` is true if `frisby_submitter` has uploaded the data to the cloud.

We are moving to an architecture where
* the sampler saves data in a local database
* the poster (submitter) reads from the local database and pushes to the cloud, also marking rows as `uploaded`
* the main updater loop/master deletes uploaded rows now and then.

This is one small step in increments, but one giant leap for #106