### PR TITLE
timeout on all requests!

### DIFF
--- a/bin/fby_client
+++ b/bin/fby_client
@@ -153,7 +153,7 @@ def network_block():
             sys.exit("No network contact established - giving up")
 
         try:
-            response = requests.get( url )
+            response = requests.get(url, timeout=10)
             if response.status_code == 200:
                 break
         except Exception:

--- a/lib/device_config.py
+++ b/lib/device_config.py
@@ -89,7 +89,7 @@ class DeviceConfig(object):
 
             try:
                 api_url = "https://api.github.com/repos/FriskByBergen/RPiParticle/git/refs/heads/%s" % self.getGitRef()
-                response = requests.get( api_url )
+                response = requests.get(api_url, timeout=10)
                 if response.status_code == 200:
                     data = json.loads( response.content )
                     new_sha = data["object"]["sha"]
@@ -118,7 +118,7 @@ class DeviceConfig(object):
             
     @classmethod
     def download(cls , url , post_key = None):
-        response = requests.get( url )
+        response = requests.get(url, timeout=10)
         if response.status_code != 200:
             raise ValueError("http GET return status:%s" % response.status_code)
 
@@ -149,7 +149,7 @@ class DeviceConfig(object):
         headers = {"Content-Type": "application/json"}
         response = requests.post("%s/sensor/api/client_log/" % self.getServerURL(),
                                  data = json_msg ,
-                                 headers = headers )
+                                 headers = headers, timeout=10)
         return response.status_code
 
 
@@ -168,4 +168,5 @@ class DeviceConfig(object):
 
         response = requests.put("%s/sensor/api/device/%s/" % (self.getServerURL(), self.getDeviceID( )), 
                                 data = json.dumps( data ) ,
-                                headers = headers )
+                                headers = headers,
+                                timeout=10)

--- a/lib/friskby_client.py
+++ b/lib/friskby_client.py
@@ -39,7 +39,7 @@ class FriskbyClient(object):
         respons = requests.post( self.device_config.getPostURL( ) ,
                                  headers=FriskbyClient.headers,
                                  data=json.dumps(data),
-                                 timeout=30)
+                                 timeout=10)
         respons.connection.close()
         if respons.status_code != 201:
             respons.raise_for_status()


### PR DESCRIPTION
Here's a stupid hypothetical scenario:

1. We try to post some data, but for some reason heroku doesn't reply within the timeout (10--30 sec)
2. This raises a timeout error
3. We try to post to heroku a log message saying that something timed out (using `requests.post` specifying no timeout!).

In the event that two consecutive posts to heroku times out, 3 will potentially hang forever.