### PR TITLE
update SDS011 params for upstream changes in python-friskby

### DIFF
--- a/rpiparticle/fby_sampler
+++ b/rpiparticle/fby_sampler
@@ -21,5 +21,5 @@ if __name__ == '__main__':
         rpi_db = sys.argv[1]
 
     DAO = FriskbyDao(rpi_db)
-    SAM = FriskbySampler(SDS011(True), DAO, sample_time)
+    SAM = FriskbySampler(SDS011('/dev/ttyUSB0'), DAO, sample_time)
     SAM.collect()


### PR DESCRIPTION
Reflect upstream changes FriskByBergen/python-friskby#14.

This will instantiate `SDS011` with the hardcoded path `ttyUSB0`, which will later be replaced with a path from FriskbySettings.

This is a step towards #118.