### PR TITLE
FriskbySubmitter takes path to config not DeviceConfig

### DIFF
--- a/rpiparticle/fby_submitter
+++ b/rpiparticle/fby_submitter
@@ -6,16 +6,16 @@ Marks uploaded data in dao as such.
 """
 from __future__ import print_function
 import sys
-from friskby import FriskbySubmitter, FriskbyDao, device_config
+from friskby import FriskbySubmitter, FriskbyDao
 from rpiparticle import fby_settings
 
 if __name__ == '__main__':
     settings = fby_settings.get_settings()
     rpi_db = settings['rpi_db']
-    device_config = device_config.DeviceConfig(settings['rpi_config_path'])
+    device_config_path = settings['rpi_config_path']
     if len(sys.argv) > 1:
         rpi_db = sys.argv[1]
 
     DAO = FriskbyDao(rpi_db)
-    SUB = FriskbySubmitter(DAO, device_config)
+    SUB = FriskbySubmitter(DAO, device_config_path)
     SUB.post()


### PR DESCRIPTION
The FriskbySubmitter takes as input a _path_ to a config, not a `DeviceConfig`.

`fby_submitter` instantiates `FriskbySubmitter` with a `DeviceConfig`.  Now, with the path.

Related to FriskByBergen/python-friskby-controlpanel/#9 